### PR TITLE
ci: add PR labeling workflow and docs for branch protection

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,17 @@
+Branch protection recommendation for `dev`
+
+Suggested settings (set via GitHub repo Settings -> Branches -> Branch protection rules):
+
+- Protect branch: `dev`
+- Require pull request reviews before merging: **Enable** (1 required review: maintainers or specific code owners)
+- Require status checks to pass before merging: **Enable** and select checks to require; at minimum:
+  - `CI - Install Dependencies` (ensures `npm ci` succeeds)
+- Require branches to be up to date before merging: **Optional** (useful to ensure merges include latest changes)
+- Require linear history: **Optional**
+- Include administrators: **Recommended** (prevents accidental bypass)
+
+Notes:
+- Only repository admins can add/update protection rules. If you want, I can apply these using the GitHub REST API (requires a token with `repo` and `admin:repo_hook` scope).
+- The PR labeler workflow is already in place to tag PRs with `ci: passed` or `ci: failed` based on `npm ci`.
+
+If you want me to apply the rules automatically, provide a temporary Personal Access Token and confirm which exact checks you want to require (I recommend `CI - Install Dependencies` at minimum).

--- a/.github/workflows/label-pr-ci.yml
+++ b/.github/workflows/label-pr-ci.yml
@@ -1,0 +1,37 @@
+name: PR Label - CI Status
+
+on:
+  workflow_run:
+    workflows: ["CI - Install Dependencies"]
+    types: [completed]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PRs based on CI result
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const conclusion = run.conclusion; // success, failure, cancelled, etc
+            const prs = run.pull_requests || [];
+            const passLabel = 'ci: passed';
+            const failLabel = 'ci: failed';
+
+            for (const pr of prs) {
+              const owner = pr.base.repo.owner.login;
+              const repo = pr.base.repo.name;
+              const number = pr.number;
+              if (conclusion === 'success') {
+                await github.issues.addLabels({ owner, repo, issue_number: number, labels: [passLabel] });
+                // try to remove fail label if present
+                try { await github.issues.removeLabel({ owner, repo, issue_number: number, name: failLabel }); } catch (e) {}
+                await github.issues.createComment({ owner, repo, issue_number: number, body: ':white_check_mark: `npm ci` succeeded — added label `ci: passed`.' });
+              } else {
+                // treat everything non-success as failure for now
+                try { await github.issues.addLabels({ owner, repo, issue_number: number, labels: [failLabel] }); } catch (e) {}
+                try { await github.issues.removeLabel({ owner, repo, issue_number: number, name: passLabel }); } catch (e) {}
+                await github.issues.createComment({ owner, repo, issue_number: number, body: ':x: `npm ci` failed — added label `ci: failed`. Please check the logs.' });
+              }
+            }


### PR DESCRIPTION
## Summary

Please describe the change and the reason for it.

## Checklist
- [x] I have confirmed the **Base repository** is `swinghouse/React-To-Do-List-Tutorial`.
- [x] I have confirmed the **Base branch** is `dev`.
- [x] I have added a clear title and description for the PR.
- [ ] I ran `npm ci` locally and confirmed installs succeed (if relevant).

> Note: If the base repo/branch is incorrect, change it using the "Edit" button on the PR page before submitting.